### PR TITLE
feat: add reasoning v1 flag

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,3 +45,11 @@ have a default absolute weight of `2.0`. Tokens with square or opposition
 aspects without reception count as negative testimony; all others are
 positive. Each dispatched entry also reports whether the aspect is
 applying via an `applying` flag in the ledger.
+
+## Reasoning output modes
+
+The `/api/calculate-chart` endpoint can return reasoning details in two formats.
+By default, responses include the legacy `rationale` array.
+Setting the `useReasoningV1` flag—either as a `useReasoningV1=true` query
+parameter or the `USE_REASONING_V1=true` environment variable—switches the
+response to the new `reasoning_v1` field and omits `rationale`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -781,6 +781,11 @@ def calculate_chart():
 
         manual_houses = data.get('manualHouses')
 
+        use_reasoning_v1 = request.args.get('useReasoningV1')
+        if use_reasoning_v1 is None:
+            use_reasoning_v1 = os.getenv('USE_REASONING_V1', 'false')
+        use_reasoning_v1 = str(use_reasoning_v1).lower() == 'true'
+
         
 
         # NEW: Extract enhanced parameters
@@ -1103,12 +1108,21 @@ def calculate_chart():
                     if 'polarity' in entry and hasattr(entry['polarity'], 'name'):
                         entry['polarity'] = entry['polarity'].name
                 result['ledger'] = ledger
-                result['rationale'] = evaluation.get('rationale', [])
+                if use_reasoning_v1:
+                    result['reasoning_v1'] = evaluation.get('rationale', [])
+                else:
+                    result['rationale'] = evaluation.get('rationale', [])
             else:
-                result['rationale'] = result.get('reasoning', [])
+                if use_reasoning_v1:
+                    result['reasoning_v1'] = result.get('reasoning', [])
+                else:
+                    result['rationale'] = result.get('reasoning', [])
         except Exception as eval_error:
             logger.warning(f"evaluate_chart failed: {eval_error}")
-            result['rationale'] = result.get('reasoning', [])
+            if use_reasoning_v1:
+                result['reasoning_v1'] = result.get('reasoning', [])
+            else:
+                result['rationale'] = result.get('reasoning', [])
 
         return jsonify(result)
 


### PR DESCRIPTION
## Summary
- support `useReasoningV1` query parameter or `USE_REASONING_V1` environment variable in chart evaluation
- when enabled, return `reasoning_v1` instead of legacy `rationale`
- document reasoning output modes in backend README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab23a5903483249aa08b36507b723e