### PR TITLE
feat: add reasoning format toggle

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -781,7 +781,9 @@ def calculate_chart():
 
         manual_houses = data.get('manualHouses')
 
-        use_reasoning_v1 = request.args.get('useReasoningV1')
+        use_reasoning_v1 = request.headers.get('X-Use-Reasoning-V1')
+        if use_reasoning_v1 is None:
+            use_reasoning_v1 = request.args.get('useReasoningV1')
         if use_reasoning_v1 is None:
             use_reasoning_v1 = os.getenv('USE_REASONING_V1', 'false')
         use_reasoning_v1 = str(use_reasoning_v1).lower() == 'true'

--- a/backend/tests/test_reasoning_flag.py
+++ b/backend/tests/test_reasoning_flag.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+
+# Ensure backend package and its modules are discoverable
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from app import app  # noqa: E402
+
+@pytest.fixture()
+def client():
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+def sample_payload():
+    return {
+        'question': 'Will I pass?',
+        'location': 'London, UK',
+        'useCurrentTime': True,
+    }
+
+
+def test_legacy_reasoning(client):
+    resp = client.post('/api/calculate-chart', json=sample_payload())
+    data = resp.get_json()
+    assert 'rationale' in data and 'reasoning_v1' not in data
+
+
+def test_reasoning_v1_via_query(client):
+    resp = client.post('/api/calculate-chart?useReasoningV1=true', json=sample_payload())
+    data = resp.get_json()
+    assert 'reasoning_v1' in data and 'rationale' not in data
+
+
+def test_reasoning_v1_via_header(client):
+    resp = client.post('/api/calculate-chart', json=sample_payload(), headers={'X-Use-Reasoning-V1': 'true'})
+    data = resp.get_json()
+    assert 'reasoning_v1' in data and 'rationale' not in data

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "build:appx-from-working": "npm run build && npm run build-backend-exe && npm run electron:pack && npm run fix-and-package",
     "validate:icons": "node validate-icons.js",
     "prebuild": "npm run validate:icons",
-    "test": "node tests/parseReasoning.test.mjs"
+    "test": "node tests/parseReasoning.test.mjs && node tests/useReasoningFlag.test.mjs"
   },
   "dependencies": {
     "lucide-react": "^0.263.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { buildChartPayload } from './utils/buildChartPayload';
 import { parseReasoningEntry } from './utils/parseReasoning.mjs';
 import { cleanMoonText } from './utils/cleanMoonText';
 import { renderReasoning } from './utils/renderReasoning';
+import { getUseReasoningV1 } from './utils/useReasoningFlag.mjs';
 
 import { 
   Calendar, 
@@ -77,6 +78,12 @@ function getApiBaseUrl() {
   return import.meta.env.VITE_API_BASE_URL || window.API_BASE_URL || 'http://localhost:5000';
 }
 
+// Determine which reasoning format to request from the backend
+const USE_REASONING_V1 = getUseReasoningV1();
+if (typeof window !== 'undefined') {
+  window.USE_REASONING_V1 = USE_REASONING_V1;
+}
+
 // API Service Layer
 class VoxStellaAPI {
   static async request(endpoint, options = {}) {
@@ -106,7 +113,8 @@ class VoxStellaAPI {
   }
 
   static async calculateChart(chartData) {
-    return this.request('/api/calculate-chart', {
+    const endpoint = `/api/calculate-chart${USE_REASONING_V1 ? '?useReasoningV1=true' : ''}`;
+    return this.request(endpoint, {
       method: 'POST',
       body: JSON.stringify(chartData),
     });

--- a/frontend/src/utils/useReasoningFlag.mjs
+++ b/frontend/src/utils/useReasoningFlag.mjs
@@ -1,0 +1,15 @@
+export function getUseReasoningV1() {
+  let queryFlag = null;
+  if (typeof window !== 'undefined' && window.location) {
+    const params = new URLSearchParams(window.location.search);
+    queryFlag = params.get('useReasoningV1');
+  }
+  if (queryFlag !== null) {
+    return queryFlag === 'true';
+  }
+  const envFlag = (import.meta.env && import.meta.env.VITE_USE_REASONING_V1) || process.env.USE_REASONING_V1;
+  if (envFlag !== undefined) {
+    return String(envFlag).toLowerCase() === 'true';
+  }
+  return false;
+}

--- a/frontend/tests/parseReasoning.test.mjs
+++ b/frontend/tests/parseReasoning.test.mjs
@@ -1,0 +1,15 @@
+import { parseReasoningEntry } from '../src/utils/parseReasoning.mjs';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const res1 = parseReasoningEntry('Good omen (5%)');
+assert(res1.rule === 'Good omen' && res1.weight === 5, 'failed to parse parenthetical weight');
+
+const res2 = parseReasoningEntry('Bad sign -3%');
+assert(res2.rule === 'Bad sign' && res2.weight === -3, 'failed to parse signed weight');
+
+console.log('parseReasoning tests passed');

--- a/frontend/tests/useReasoningFlag.test.mjs
+++ b/frontend/tests/useReasoningFlag.test.mjs
@@ -1,0 +1,20 @@
+import { getUseReasoningV1 } from '../src/utils/useReasoningFlag.mjs';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+global.window = { location: { search: '' } };
+process.env.USE_REASONING_V1 = 'true';
+assert(getUseReasoningV1() === true, 'env flag true should enable reasoning v1');
+
+process.env.USE_REASONING_V1 = 'false';
+window.location.search = '?useReasoningV1=true';
+assert(getUseReasoningV1() === true, 'query param should override env');
+
+window.location.search = '?useReasoningV1=false';
+assert(getUseReasoningV1() === false, 'explicit false should disable reasoning v1');
+
+console.log('useReasoningFlag tests passed');


### PR DESCRIPTION
## Summary
- allow frontend to opt into new reasoning format via USE_REASONING_V1 runtime flag
- backend honors USE_REASONING_V1 header or query param to emit matching reasoning field
- cover both reasoning formats with unit tests

## Testing
- `npm test`
- `pytest backend/tests/test_reasoning_flag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2a09dac88324b23d61088b09c6b5