### PR TITLE
Guard reasoning flag env access

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_USE_REASONING_V1=false

--- a/frontend/src/utils/useReasoningFlag.mjs
+++ b/frontend/src/utils/useReasoningFlag.mjs
@@ -7,7 +7,9 @@ export function getUseReasoningV1() {
   if (queryFlag !== null) {
     return queryFlag === 'true';
   }
-  const envFlag = (import.meta.env && import.meta.env.VITE_USE_REASONING_V1) || process.env.USE_REASONING_V1;
+  const envFlag =
+    import.meta.env?.VITE_USE_REASONING_V1 ??
+    (typeof process !== 'undefined' ? process.env.USE_REASONING_V1 : undefined);
   if (envFlag !== undefined) {
     return String(envFlag).toLowerCase() === 'true';
   }


### PR DESCRIPTION
## Summary
- guard process.env access when reading reasoning flag
- add `.env` toggle for `VITE_USE_REASONING_V1`

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'validate-icons.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab30d2df608324880f522f60d7b95a