### PR TITLE
Use tolerance for retrograde sign boundary check

### DIFF
--- a/backend/horary_engine/calculation/helpers.py
+++ b/backend/horary_engine/calculation/helpers.py
@@ -147,7 +147,7 @@ def calculate_sign_boundary_longitude(current_longitude: float, direction: int) 
             next_boundary = 0
     else:  # Retrograde motion - previous sign backward
         next_boundary = current_sign_start
-        if current_longitude == current_sign_start:  # Exactly on boundary
+        if abs(current_longitude - current_sign_start) < 1e-6:  # Exactly on boundary
             next_boundary = current_sign_start - 30
             if next_boundary < 0:
                 next_boundary = 330


### PR DESCRIPTION
## Summary
- guard retrograde sign boundary equality with a 1e-6 tolerance to handle floating point rounding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb95a480c8324b11bcab236e24e0a