### PR TITLE
Expose translation timing thresholds in config

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -106,6 +106,8 @@ translation:
   require_speed_advantage: true  # Translator must be faster than significators
   require_proper_sequence: true   # Must separate then apply
   require_reception: false        # Reception not mandatory
+  max_separation_deg: 10.0        # Maximum degrees past exact for separating aspect
+  max_application_deg: 15.0       # Maximum degrees to exact for applying aspect
 
 collection:
   require_collector_dignity: true # Collector should be dignified

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -5310,13 +5310,17 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         if hasattr(separating_aspect, 'degrees_to_exact') and hasattr(applying_aspect, 'degrees_to_exact'):
             # For separating aspect, degrees_to_exact represents how far past exact
             # For applying aspect, degrees_to_exact represents how far to exact
-            
+
+            translation_cfg = getattr(cfg(), "translation", SimpleNamespace())
+            max_sep = getattr(translation_cfg, "max_separation_deg", 10.0)
+            max_app = getattr(translation_cfg, "max_application_deg", 15.0)
+
             # Additional validation: ensure the separation is recent enough to be meaningful
-            if separating_aspect.degrees_to_exact > 10.0:  # Too far past exact
+            if separating_aspect.degrees_to_exact > max_sep:  # Too far past exact
                 return False
-                
+
             # Ensure application is upcoming (not too far away)
-            if applying_aspect.degrees_to_exact > 15.0:  # Too far to exact
+            if applying_aspect.degrees_to_exact > max_app:  # Too far to exact
                 return False
         
         return True


### PR DESCRIPTION
## Summary
- add `translation.max_separation_deg` and `translation.max_application_deg` config options
- use the config thresholds in translation sequence timing validation
- document new defaults in `horary_constants.yaml`

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbc606abc8324b981eb26047205b7